### PR TITLE
feat: Update README, add canvas-workspace, and basic styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,15 @@ A standalone, offline-capable web application for creating and simulating dynami
 - **Status bar** - Current mode, cursor position, zoom level
 - **Context menus** - Right-click actions for canvas and elements
 
+## Development Environment
+This project uses [Vite.js](https://vitejs.dev/) for its development server and build processes, providing a fast and modern development experience. For testing, we use [Vitest](https://vitest.dev/), a Vite-native testing framework.
+
+All new features, components, or significant code changes must be accompanied by unit tests to ensure code quality and maintainability.
+
+Key commands:
+- To start the development server: `npm run dev`
+- To run tests: `npm test`
+
 ## Technical Architecture
 
 ### Web Components Structure

--- a/src/app-shell/app-shell.css
+++ b/src/app-shell/app-shell.css
@@ -1,0 +1,6 @@
+/*
+  Basic styles for app-shell component.
+  Currently, the primary styles are embedded directly within app-shell.js
+  for encapsulation without Shadow DOM. This file is created to align with
+  the project structure but might be used more extensively if styles are externalized.
+*/

--- a/src/app-shell/app-shell.js
+++ b/src/app-shell/app-shell.js
@@ -9,14 +9,62 @@ class AppShell extends BaseComponent {
 
   connectedCallback() {
     this.innerHTML = `
+      <style>
+        /* Styles for app-shell component */
+        app-shell { /* Since it's not shadow DOM, we target the element itself */
+            display: flex;
+            flex-direction: column;
+            height: 100vh;
+            width: 100vw; /* Changed from 100% to 100vw for full viewport width */
+            margin: 0;
+            font-family: sans-serif;
+            background-color: #fff; /* Default background for the shell */
+        }
+
+        app-shell > header,
+        app-shell > footer {
+            padding: 10px;
+            background-color: #e0e0e0; /* Light grey */
+            flex-shrink: 0; /* Prevent shrinking */
+            text-align: center;
+        }
+
+        app-shell > .content-wrapper { /* New class for the div containing nav and main */
+            display: flex;
+            flex-grow: 1; /* Takes up remaining space */
+            overflow: hidden; /* Prevent content from breaking layout */
+        }
+
+        app-shell nav {
+            width: 200px;
+            border-right: 1px solid #ccc;
+            padding: 10px;
+            background-color: #f0f0f0; /* Slightly different grey for nav */
+            flex-shrink: 0;
+            overflow-y: auto; /* If nav content gets long */
+        }
+
+        app-shell main {
+            flex-grow: 1;
+            padding: 10px;
+            display: flex; /* To allow canvas-workspace to fill it */
+            flex-direction: column; /* If we add other things in main */
+        }
+
+        /* Ensure canvas-workspace (if present) can fill the main area */
+        app-shell main canvas-workspace {
+            flex-grow: 1;
+            border: 1px dashed #aaa; /* For visualizing its bounds during dev */
+        }
+      </style>
       <header>
         <h1>Dynamic Systems Modeler</h1>
       </header>
-      <div style="display: flex; min-height: calc(100vh - 150px);"> <!-- Adjust min-height as needed -->
-        <nav style="width: 200px; border-right: 1px solid #ccc; padding: 10px; background-color: #f0f0f0;">
+      <div class="content-wrapper">
+        <nav>
           <symbol-library></symbol-library>
         </nav>
-        <main style="flex-grow: 1; padding: 10px;">
+        <main>
           <p>Main application content will go here. The canvas-workspace will eventually replace this.</p>
           <!-- Placeholder for canvas-workspace -->
           <!-- <canvas-workspace></canvas-workspace> -->

--- a/src/canvas-workspace/canvas-workspace.css
+++ b/src/canvas-workspace/canvas-workspace.css
@@ -1,0 +1,2 @@
+/* Styles for canvas-workspace component */
+/* Initially empty as styles are embedded in JS for encapsulation */

--- a/src/canvas-workspace/canvas-workspace.js
+++ b/src/canvas-workspace/canvas-workspace.js
@@ -1,9 +1,37 @@
-import BaseComponent from '../BaseComponent.js';
+import BaseComponent from '../../BaseComponent.js';
 
 class CanvasWorkspace extends BaseComponent {
-  constructor() {
-    super();
-  }
+    constructor() {
+        super();
+        this.attachShadow({ mode: 'open' });
+        this.shadowRoot.innerHTML = `
+            <style>
+                :host {
+                    display: block;
+                    width: 100%;
+                    height: 100%;
+                    overflow: hidden; /* To contain pan/zoom later */
+                    background-color: #f0f0f0; /* Light grey background */
+                    border: 1px solid #ccc; /* Subtle border */
+                    box-sizing: border-box;
+                }
+                svg {
+                    width: 100%;
+                    height: 100%;
+                }
+            </style>
+            <svg id="canvas-svg" width="100%" height="100%"></svg>
+        `;
+    }
+
+    connectedCallback() {
+        // Perform any initial setup after the component is connected to the DOM
+        // For example, you might want to get a reference to the SVG element:
+        // this.svgCanvas = this.shadowRoot.getElementById('canvas-svg');
+        console.log('canvas-workspace connected');
+    }
+
+    // Add other methods for pan, zoom, drawing, etc. later
 }
 
 customElements.define('canvas-workspace', CanvasWorkspace);

--- a/src/canvas-workspace/canvas-workspace.test.js
+++ b/src/canvas-workspace/canvas-workspace.test.js
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import './canvas-workspace.js'; // Adjust path as necessary if component is in a different directory
+
+describe('CanvasWorkspace', () => {
+  let element;
+  let container;
+
+  beforeEach(() => {
+    // Create a container for the element to be appended to
+    container = document.createElement('div');
+    document.body.appendChild(container);
+
+    element = document.createElement('canvas-workspace');
+    container.appendChild(element);
+  });
+
+  afterEach(() => {
+    if (element && element.parentNode) {
+      element.parentNode.removeChild(element);
+    }
+    if (container && container.parentNode) {
+      container.parentNode.removeChild(container);
+    }
+    element = null;
+    container = null;
+  });
+
+  it('should be defined as a custom element', () => {
+    const Ctor = customElements.get('canvas-workspace');
+    expect(Ctor).toBeDefined();
+    expect(element).toBeInstanceOf(Ctor);
+    // Also check it's not a generic HTMLUnknownElement
+    expect(element).not.toBeInstanceOf(HTMLUnknownElement);
+  });
+
+  it('should have a shadowRoot', () => {
+    expect(element.shadowRoot).toBeDefined();
+    expect(element.shadowRoot).not.toBeNull();
+  });
+
+  it('should have an SVG element in its shadow DOM', () => {
+    // Ensure shadowRoot is present before querying
+    expect(element.shadowRoot).toBeDefined();
+    const svgElement = element.shadowRoot.querySelector('svg');
+    expect(svgElement).not.toBeNull();
+    expect(svgElement).toBeInstanceOf(SVGElement);
+  });
+
+  it('should have the id "canvas-svg" for the svg element', () => {
+    expect(element.shadowRoot).toBeDefined();
+    const svgElement = element.shadowRoot.querySelector('svg#canvas-svg');
+    expect(svgElement).not.toBeNull();
+    // Check if the id attribute is indeed 'canvas-svg'
+    expect(svgElement.getAttribute('id')).toBe('canvas-svg');
+  });
+
+  it('should have width and height attributes set to 100% on the svg element', () => {
+    expect(element.shadowRoot).toBeDefined();
+    const svgElement = element.shadowRoot.querySelector('svg#canvas-svg');
+    expect(svgElement).not.toBeNull();
+    expect(svgElement.getAttribute('width')).toBe('100%');
+    expect(svgElement.getAttribute('height')).toBe('100%');
+  });
+});


### PR DESCRIPTION
This commit introduces several updates:

1.  **README.md Updated:**
    *   I added a "Development Environment" section.
    *   I detailed the use of Vite.js for development and Vitest for testing.
    *   I emphasized the requirement for unit tests for new features.
    *   I listed standard commands (`npm run dev`, `npm test`).

2.  **New `canvas-workspace` Component:**
    *   I created `src/canvas-workspace/canvas-workspace.js` as a Web Component extending `BaseComponent`.
    *   It includes an SVG element (`#canvas-svg`) for future drawing.
    *   I embedded basic CSS for initial styling (full size, light background).
    *   I also added an empty `src/canvas-workspace/canvas-workspace.css`.

3.  **Styling for `app-shell`:**
    *   I enhanced `src/app-shell/app-shell.js` by embedding CSS styles.
    *   This ensures `app-shell` uses the full viewport.
    *   It implements a flexbox layout for its main children (header, content, footer).
    *   This provides a clean and professional base appearance.

4.  **Tests for `canvas-workspace`:**
    *   I added `src/canvas-workspace/canvas-workspace.test.js`.
    *   This includes Vitest tests to verify the component's registration,
        the existence of its shadow DOM, and the presence and basic
        attributes of the SVG element.

These changes address the issue by updating documentation, progressing on the tasks, and applying initial professional styling.