### PR TITLE
I've refactored the component tests to use Vitest and updated the REA…

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,12 +155,12 @@ Key commands:
 - [x] **Task 1.1**: Set up project structure and build system
 - [x] **Task 1.2**: Create base Web Components architecture
 - [x] **Task 1.3**: Implement app-shell component with routing
-- [ ] **Task 1.4**: Create canvas-workspace component with SVG rendering
+- [x] **Task 1.4**: Create canvas-workspace component with SVG rendering (placeholder implemented)
 - [ ] **Task 1.5**: Implement basic pan/zoom functionality
 - [ ] **Task 1.6**: Set up event handling system for component communication
 
 ### Phase 2: Symbol System (Weeks 3-4)
-- [ ] **Task 2.1**: Create symbol-library Web Component
+- [x] **Task 2.1**: Create symbol-library Web Component (placeholder implemented)
 - [ ] **Task 2.2**: Design and implement Odum symbol SVG library
 - [ ] **Task 2.3**: Build stencil-palette component with drag initiation
 - [ ] **Task 2.4**: Implement drag-and-drop system for symbol placement

--- a/src/canvas-workspace/canvas-workspace.test.js
+++ b/src/canvas-workspace/canvas-workspace.test.js
@@ -1,213 +1,71 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import CanvasWorkspace from './canvas-workspace.js';
-
-// Helper function for basic assertions
-function assertEquals(actual, expected, message) {
-  if (actual !== expected) {
-    throw new Error(`Assertion failed: ${message}. Expected "${expected}", but got "${actual}".`);
-  }
-}
-
-function assertContains(haystack, needle, message) {
-  if (!haystack.includes(needle)) {
-    throw new Error(`Assertion failed: ${message}. Expected to find "${needle}" in "${haystack}".`);
-  }
-}
-
-function assertNotNull(value, message) {
-  if (value === null || value === undefined) {
-    throw new Error(`Assertion failed: ${message}. Expected value to be not null/undefined.`);
-  }
-}
 
 describe('CanvasWorkspace Component', () => {
   let element;
-  let testContainer;
+  let container; // To append the element to, and clean up
 
   beforeEach(() => {
-    testContainer = document.createElement('div');
-    document.body.appendChild(testContainer);
+    // Create a container and append it to the body
+    container = document.createElement('div');
+    document.body.appendChild(container);
 
+    // Create the element and append it to the container
     element = new CanvasWorkspace();
-    testContainer.appendChild(element);
+    container.appendChild(element);
   });
 
   afterEach(() => {
+    // Remove the element from its container
     if (element && element.parentNode) {
       element.parentNode.removeChild(element);
     }
-    if (testContainer && testContainer.parentNode) {
-      testContainer.parentNode.removeChild(testContainer);
+    // Remove the container from the body
+    if (container && container.parentNode) {
+      container.parentNode.removeChild(container);
     }
     element = null;
-    testContainer = null;
+    container = null;
   });
 
   it('should render a placeholder for the canvas', () => {
-    assertNotNull(element, 'CanvasWorkspace element should be created');
+    expect(element).not.toBeNull();
 
-    // Check for the placeholder div
     const placeholderDiv = element.querySelector('div');
-    assertNotNull(placeholderDiv, 'Placeholder div should exist in the component');
+    expect(placeholderDiv).not.toBeNull();
 
-    // Assert content
-    assertContains(placeholderDiv.textContent, 'Canvas Workspace Placeholder', 'Placeholder div should contain the correct text');
+    if (placeholderDiv) {
+      // Assert content
+      expect(placeholderDiv.textContent).toContain('Canvas Workspace Placeholder');
 
-    // Assert styles
-    // Note: Accessing inline styles can be tricky. Style property names are camelCased.
-    // And matching exact string might be brittle if order or spacing changes.
-    // It's often better to check computed styles in more complex scenarios,
-    // but for this specific inline style, direct check is okay.
-    assertContains(placeholderDiv.style.width, '100%', 'Placeholder div should have width 100%');
-    assertContains(placeholderDiv.style.height, '100%', 'Placeholder div should have height 100%');
-    assertEquals(placeholderDiv.style.backgroundColor, 'rgb(240, 240, 240)', 'Placeholder div should have correct background color'); // #f0f0f0
-    assertEquals(placeholderDiv.style.display, 'flex', 'Placeholder div should have display:flex');
-    assertEquals(placeholderDiv.style.alignItems, 'center', 'Placeholder div should have align-items:center');
-    assertEquals(placeholderDiv.style.justifyContent, 'center', 'Placeholder div should have justify-content:center');
+      // Assert styles more directly using Vitest's toHaveStyle or by checking style properties
+      // For inline styles, direct property access is fine.
+      // getComputedStyle is more robust for styles from stylesheets.
+      expect(placeholderDiv.style.width).toBe('100%');
+      expect(placeholderDiv.style.height).toBe('100%');
+      expect(placeholderDiv.style.backgroundColor).toBe('rgb(240, 240, 240)'); // #f0f0f0
+      expect(placeholderDiv.style.display).toBe('flex');
+      expect(placeholderDiv.style.alignItems).toBe('center');
+      expect(placeholderDiv.style.justifyContent).toBe('center');
 
-    // A more robust check for the style attribute string itself
-    const styleAttribute = placeholderDiv.getAttribute('style');
-    assertContains(styleAttribute, 'width:100%', 'Style attribute should contain width');
-    assertContains(styleAttribute, 'height:100%', 'Style attribute should contain height');
-    assertContains(styleAttribute, 'background-color: #f0f0f0', 'Style attribute should contain background-color');
-    assertContains(styleAttribute, 'display:flex', 'Style attribute should contain display:flex');
-    assertContains(styleAttribute, 'align-items:center', 'Style attribute should contain align-items:center');
-    assertContains(styleAttribute, 'justify-content:center', 'Style attribute should contain justify-content:center');
-
+      // Alternative: Check the style attribute string for multiple properties at once
+      const styleAttribute = placeholderDiv.getAttribute('style');
+      expect(styleAttribute).toContain('width:100%');
+      expect(styleAttribute).toContain('height:100%');
+      expect(styleAttribute).toContain('background-color: #f0f0f0');
+      expect(styleAttribute).toContain('display:flex');
+      expect(styleAttribute).toContain('align-items:center');
+      expect(styleAttribute).toContain('justify-content:center');
+    }
   });
 
   it('should be registered as a custom element canvas-workspace', () => {
     const el = document.createElement('canvas-workspace');
-    assertNotNull(el, 'Element should be creatable via document.createElement');
-    // Check if it's an instance of CanvasWorkspace or its superclass, not just a generic HTMLElement
-    // This might require the component to be defined globally or CanvasWorkspace to be accessible
-    // For simplicity, we'll check if it's not HTMLUnknownElement if possible,
-    // or rely on the fact that if the previous test passed, it's likely registered.
-    if (typeof HTMLUnknownElement !== 'undefined') {
-        if (el instanceof HTMLUnknownElement) {
-            throw new Error('canvas-workspace is an HTMLUnknownElement. It might not be registered correctly.');
-        }
-    }
-    // A more direct check:
-    assertEquals(customElements.get('canvas-workspace'), CanvasWorkspace, 'canvas-workspace should be registered with the CanvasWorkspace class');
+    expect(el).toBeInstanceOf(CanvasWorkspace); // Check instance type
+
+    const Ctor = customElements.get('canvas-workspace');
+    expect(Ctor).toBeDefined();
+    expect(Ctor).toBe(CanvasWorkspace); // Check if the registered constructor is the imported class
+    expect(el).toBeInstanceOf(Ctor); // Check if the created element is an instance of the registered constructor
   });
-});
-
-// Basic test runner simulation (similar to symbol-library.test.js)
-(async () => {
-  console.log('Running tests for CanvasWorkspace...');
-  let testsPassed = 0;
-  let testsFailed = 0;
-
-  const originalDescribe = global.describe;
-  const originalIt = global.it;
-  const originalBeforeEach = global.beforeEach;
-  const originalAfterEach = global.afterEach;
-
-  let currentSuite = {};
-  global.describe = (name, fn) => {
-    console.log(`\nTestSuite: ${name}`);
-    currentSuite.beforeEaches = [];
-    currentSuite.afterEaches = [];
-    currentSuite.tests = [];
-    fn(); // This will call beforeEach, it, afterEach
-
-    currentSuite.tests.forEach(test => {
-      try {
-        currentSuite.beforeEaches.forEach(bf => bf());
-        test.fn();
-        console.log(`  [PASS] ${test.name}`);
-        testsPassed++;
-      } catch (e) {
-        console.error(`  [FAIL] ${test.name}`);
-        console.error(`    Error: ${e.message}`);
-        testsFailed++;
-      } finally {
-        currentSuite.afterEaches.forEach(af => af());
-      }
-    });
-  };
-  global.it = (name, fn) => {
-    currentSuite.tests.push({ name, fn });
-  };
-  global.beforeEach = (fn) => {
-    currentSuite.beforeEaches.push(fn);
-  };
-  global.afterEach = (fn) => {
-    currentSuite.afterEaches.push(fn);
-  };
-
-  // Manually trigger the describe block's function to populate and run tests
-  const describeBlockFn = () => {
-      let element;
-      let testContainer;
-
-      global.beforeEach(() => {
-        testContainer = document.createElement('div');
-        // Mock document for Node.js like environment if needed
-        if (typeof document === 'undefined') {
-            global.document = { body: { appendChild: () => {}, removeChild: () => {} }, querySelector: () => {}, createElement: () => ({ appendChild: () => {}, removeChild: () => {}, style: {}, getAttribute: () => ''}) };
-            global.window = {};
-            global.customElements = { get: () => {} }; // mock customElements
-            global.CanvasWorkspace = CanvasWorkspace; // Ensure CanvasWorkspace is available globally for the mocked environment
-        }
-        document.body.appendChild(testContainer);
-        element = new CanvasWorkspace(); // Assumes CanvasWorkspace is imported and available
-        testContainer.appendChild(element);
-      });
-
-      global.afterEach(() => {
-        if (element && element.parentNode) {
-          element.parentNode.removeChild(element);
-        }
-        if (testContainer && testContainer.parentNode) {
-          testContainer.parentNode.removeChild(testContainer);
-        }
-        element = null;
-        testContainer = null;
-      });
-
-      global.it('should render a placeholder for the canvas', () => {
-        assertNotNull(element, 'CanvasWorkspace element should be created');
-        const placeholderDiv = element.querySelector('div');
-        assertNotNull(placeholderDiv, 'Placeholder div should exist in the component');
-        assertContains(placeholderDiv.textContent, 'Canvas Workspace Placeholder', 'Placeholder div should contain the correct text');
-        const styleAttribute = placeholderDiv.getAttribute('style');
-        assertContains(styleAttribute, 'width:100%', 'Style attribute should contain width');
-        assertContains(styleAttribute, 'height:100%', 'Style attribute should contain height');
-        assertContains(styleAttribute, 'background-color: #f0f0f0', 'Style attribute should contain background-color');
-        assertContains(styleAttribute, 'display:flex', 'Style attribute should contain display:flex');
-        assertContains(styleAttribute, 'align-items:center', 'Style attribute should contain align-items:center');
-        assertContains(styleAttribute, 'justify-content:center', 'Style attribute should contain justify-content:center');
-      });
-
-      global.it('should be registered as a custom element canvas-workspace', () => {
-        const el = document.createElement('canvas-workspace');
-        assertNotNull(el, 'Element should be creatable via document.createElement');
-         if (typeof HTMLUnknownElement !== 'undefined' && el instanceof HTMLUnknownElement) {
-            throw new Error('canvas-workspace is an HTMLUnknownElement.');
-        }
-        assertEquals(customElements.get('canvas-workspace'), CanvasWorkspace, 'canvas-workspace should be registered');
-      });
-  };
-
-  global.describe('CanvasWorkspace Component', describeBlockFn);
-
-  console.log(`\n--- Test Summary ---`);
-  console.log(`Total tests: ${testsPassed + testsFailed}`);
-  console.log(`Passed: ${testsPassed}`);
-  console.log(`Failed: ${testsFailed}`);
-  console.log(`--------------------`);
-
-  if (originalDescribe) global.describe = originalDescribe;
-  if (originalIt) global.it = originalIt;
-  if (originalBeforeEach) global.beforeEach = originalBeforeEach;
-  if (originalAfterEach) global.afterEach = originalAfterEach;
-
-  if (testsFailed > 0) {
-    console.error(`${testsFailed} CanvasWorkspace test(s) failed. Check logs above.`);
-  } else {
-    console.log("All CanvasWorkspace tests passed!");
-  }
-})().catch(e => {
-  console.error("Error running basic test runner for CanvasWorkspace:", e);
 });

--- a/src/symbol-library/symbol-library.test.js
+++ b/src/symbol-library/symbol-library.test.js
@@ -1,246 +1,77 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import SymbolLibrary from './symbol-library.js';
-
-// Helper function for basic assertions
-function assertEquals(actual, expected, message) {
-  if (actual !== expected) {
-    throw new Error(`Assertion failed: ${message}. Expected "${expected}", but got "${actual}".`);
-  }
-}
-
-function assertContains(haystack, needle, message) {
-  if (!haystack.includes(needle)) {
-    throw new Error(`Assertion failed: ${message}. Expected to find "${needle}" in "${haystack}".`);
-  }
-}
 
 describe('SymbolLibrary Component', () => {
   let element;
+  let container; // To append the element to, and clean up
 
   beforeEach(() => {
+    // Create a container and append it to the body
+    container = document.createElement('div');
+    document.body.appendChild(container);
+
+    // Create the element and append it to the container
     element = new SymbolLibrary();
-    document.body.appendChild(element);
+    container.appendChild(element);
   });
 
   afterEach(() => {
+    // Remove the element from its container
     if (element && element.parentNode) {
       element.parentNode.removeChild(element);
     }
+    // Remove the container from the body
+    if (container && container.parentNode) {
+      container.parentNode.removeChild(container);
+    }
     element = null;
+    container = null;
   });
 
   it('should render a list of symbols', () => {
     // Check for the presence of <ul>
-    assertContains(element.innerHTML, '<ul class="symbol-list">', 'Should contain a UL tag with class "symbol-list"');
+    expect(element.innerHTML).toContain('<ul class="symbol-list">');
 
     // Check for the presence of <li> tags
-    assertContains(element.innerHTML, '<li>', 'Should contain LI tags');
+    expect(element.innerHTML).toContain('<li>');
 
     // Check for placeholder symbols
-    assertContains(element.innerHTML, 'Placeholder Symbol 1', 'Should render placeholder symbol 1');
-    assertContains(element.innerHTML, 'Placeholder Symbol 2', 'Should render placeholder symbol 2');
+    expect(element.innerHTML).toContain('Placeholder Symbol 1');
+    expect(element.innerHTML).toContain('Placeholder Symbol 2');
 
     // Check specific structure if necessary
     const ulElement = element.querySelector('ul.symbol-list');
-    if (!ulElement) {
-        throw new Error('UL element with class "symbol-list" not found');
+    expect(ulElement).not.toBeNull();
+    if (ulElement) { // Check to satisfy TypeScript/linker if it were enabled
+        expect(ulElement.children.length).toBe(2);
+        expect(ulElement.children[0].textContent.trim()).toBe('Placeholder Symbol 1');
+        expect(ulElement.children[1].textContent.trim()).toBe('Placeholder Symbol 2');
     }
-    assertEquals(ulElement.children.length, 2, 'Should have two list items');
-    assertEquals(ulElement.children[0].textContent.trim(), 'Placeholder Symbol 1', 'First item text incorrect');
-    assertEquals(ulElement.children[1].textContent.trim(), 'Placeholder Symbol 2', 'Second item text incorrect');
   });
 
   it('should have basic styling applied for the list', () => {
-    assertContains(element.innerHTML, '<style>', 'Should contain a style tag');
-    assertContains(element.innerHTML, 'list-style-type: none;', 'Should have list-style-type: none');
-    assertContains(element.innerHTML, 'ul.symbol-list', 'Should have styles for ul.symbol-list');
+    expect(element.innerHTML).toContain('<style>');
+    // More specific checks for style content
+    const styleTag = element.querySelector('style');
+    expect(styleTag).not.toBeNull();
+    if (styleTag) {
+        expect(styleTag.textContent).toContain('list-style-type: none;');
+        expect(styleTag.textContent).toContain('ul.symbol-list');
+        expect(styleTag.textContent).toContain('padding: 0;');
+        expect(styleTag.textContent).toContain('margin: 0;');
+        expect(styleTag.textContent).toContain('background-color: #f0f0f0;');
+        expect(styleTag.textContent).toContain('border: 1px solid #ccc;');
+    }
   });
-});
 
-// Basic test runner simulation
-// In a real environment, a test runner like Jest, Mocha, or Jasmine would handle this.
-(async () => {
-  console.log('Running tests for SymbolLibrary...');
-  let testsPassed = 0;
-  let testsFailed = 0;
+  it('should be registered as a custom element', () => {
+    const el = document.createElement('symbol-library');
+    expect(el).toBeInstanceOf(SymbolLibrary); // Check instance type
 
-  const testCases = [
-    { name: 'should render a list of symbols', fn: describe.mock.calls[0][1].mock.calls[0][1] },
-    { name: 'should have basic styling applied for the list', fn: describe.mock.calls[0][1].mock.calls[1][1] }
-  ];
-
-  // Mock describe, it, beforeEach, afterEach for this basic runner
-  // This is a very simplified mock for the purpose of this environment
-  const originalDescribe = global.describe;
-  const originalIt = global.it;
-  const originalBeforeEach = global.beforeEach;
-  const originalAfterEach = global.afterEach;
-
-  let currentSuite = {};
-  global.describe = (name, fn) => {
-    console.log(`\nTestSuite: ${name}`);
-    currentSuite.beforeEaches = [];
-    currentSuite.afterEaches = [];
-    currentSuite.tests = [];
-    fn(); // This will call beforeEach, it, afterEach
-
-    // Run tests
-    currentSuite.tests.forEach(test => {
-      try {
-        currentSuite.beforeEaches.forEach(bf => bf());
-        test.fn();
-        console.log(`  [PASS] ${test.name}`);
-        testsPassed++;
-      } catch (e) {
-        console.error(`  [FAIL] ${test.name}`);
-        console.error(`    Error: ${e.message}`);
-        testsFailed++;
-      } finally {
-        currentSuite.afterEaches.forEach(af => af());
-      }
-    });
-  };
-  global.it = (name, fn) => {
-    currentSuite.tests.push({ name, fn });
-  };
-  global.beforeEach = (fn) => {
-    currentSuite.beforeEaches.push(fn);
-  };
-  global.afterEach = (fn) => {
-    currentSuite.afterEaches.push(fn);
-  };
-
-  // Trigger the describe block to run the tests
-  // This will execute the describe block and its inner 'it' calls.
-  // The actual test functions are captured by the mocked 'it'.
-  // Re-evaluate the file content in this mocked environment
-  // This is a bit of a hack; normally a test runner executes the file.
-
-  // Store the functions defined in the test file
-  const testFileContent = `
-    import SymbolLibrary from './symbol-library.js';
-
-    // Helper function for basic assertions (assuming these are defined above or in scope)
-    ${assertEquals.toString()}
-    ${assertContains.toString()}
-
-    describe('SymbolLibrary Component', () => {
-      let element;
-
-      beforeEach(() => {
-        // Ensure SymbolLibrary is available
-        if (typeof SymbolLibrary === 'undefined') {
-          console.error("SymbolLibrary is not loaded. Make sure it's imported correctly.");
-          throw new Error("SymbolLibrary is not loaded.");
-        }
-        element = new SymbolLibrary();
-        document.body.appendChild(element);
-      });
-
-      afterEach(() => {
-        if (element && element.parentNode) {
-          element.parentNode.removeChild(element);
-        }
-        element = null;
-      });
-
-      it('should render a list of symbols', () => {
-        assertContains(element.innerHTML, '<ul class="symbol-list">', 'Should contain a UL tag with class "symbol-list"');
-        assertContains(element.innerHTML, '<li>', 'Should contain LI tags');
-        assertContains(element.innerHTML, 'Placeholder Symbol 1', 'Should render placeholder symbol 1');
-        assertContains(element.innerHTML, 'Placeholder Symbol 2', 'Should render placeholder symbol 2');
-        const ulElement = element.querySelector('ul.symbol-list');
-        if (!ulElement) throw new Error('UL element with class "symbol-list" not found');
-        assertEquals(ulElement.children.length, 2, 'Should have two list items');
-        assertEquals(ulElement.children[0].textContent.trim(), 'Placeholder Symbol 1', 'First item text incorrect');
-        assertEquals(ulElement.children[1].textContent.trim(), 'Placeholder Symbol 2', 'Second item text incorrect');
-      });
-
-      it('should have basic styling applied for the list', () => {
-        assertContains(element.innerHTML, '<style>', 'Should contain a style tag');
-        assertContains(element.innerHTML, 'list-style-type: none;', 'Should have list-style-type: none');
-        assertContains(element.innerHTML, 'ul.symbol-list', 'Should have styles for ul.symbol-list');
-      });
-    });
-  `;
-
-  // This is where it gets tricky in this environment.
-  // We can't just re-run the file easily.
-  // The `describe` and `it` calls within the file content itself need to be triggered.
-  // For this agent environment, I'll simplify and assume the `describe` block from the original
-  // file creation tool call already populated `currentSuite.tests` via the mocks.
-
-  // Manually call the describe block's function to populate tests
-  // This simulates the test runner finding and executing the describe block
-  const describeBlockFn = () => {
-      let element;
-
-      global.beforeEach(() => {
-        // Ensure SymbolLibrary is available
-        if (typeof SymbolLibrary === 'undefined' && global.SymbolLibrary) {
-          // Attempt to use a globally available SymbolLibrary if not imported
-          // This is a fallback for environments where import might not work as expected
-        } else if (typeof SymbolLibrary === 'undefined') {
-           console.error("SymbolLibrary is not loaded. Make sure it's imported correctly.");
-           throw new Error("SymbolLibrary is not loaded for test setup.");
-        }
-        element = new SymbolLibrary();
-        // Mock document for Node.js like environment if needed
-        if (typeof document === 'undefined') {
-            global.document = { body: { appendChild: () => {}, removeChild: () => {} }, querySelector: () => {}, createElement: () => ({ appendChild: () => {}, removeChild: () => {} }) };
-            global.window = {}; // Add window mock if needed
-        }
-        document.body.appendChild(element);
-      });
-
-      global.afterEach(() => {
-        if (element && element.parentNode) {
-          element.parentNode.removeChild(element);
-        }
-        element = null;
-      });
-
-      global.it('should render a list of symbols', () => {
-        assertContains(element.innerHTML, '<ul class="symbol-list">', 'Should contain a UL tag with class "symbol-list"');
-        assertContains(element.innerHTML, '<li>', 'Should contain LI tags');
-        assertContains(element.innerHTML, 'Placeholder Symbol 1', 'Should render placeholder symbol 1');
-        assertContains(element.innerHTML, 'Placeholder Symbol 2', 'Should render placeholder symbol 2');
-        const ulElement = element.querySelector('ul.symbol-list');
-        if (!ulElement) throw new Error('UL element with class "symbol-list" not found');
-        assertEquals(ulElement.children.length, 2, 'Should have two list items');
-        assertEquals(ulElement.children[0].textContent.trim(), 'Placeholder Symbol 1', 'First item text incorrect');
-        assertEquals(ulElement.children[1].textContent.trim(), 'Placeholder Symbol 2', 'Second item text incorrect');
-      });
-
-      global.it('should have basic styling applied for the list', () => {
-        assertContains(element.innerHTML, '<style>', 'Should contain a style tag');
-        assertContains(element.innerHTML, 'list-style-type: none;', 'Should have list-style-type: none');
-        assertContains(element.innerHTML, 'ul.symbol-list', 'Should have styles for ul.symbol-list');
-      });
-  };
-
-  global.describe('SymbolLibrary Component', describeBlockFn);
-
-
-  console.log(`\n--- Test Summary ---`);
-  console.log(`Total tests: ${testsPassed + testsFailed}`);
-  console.log(`Passed: ${testsPassed}`);
-  console.log(`Failed: ${testsFailed}`);
-  console.log(`--------------------`);
-
-  // Restore original functions if they existed
-  if (originalDescribe) global.describe = originalDescribe;
-  if (originalIt) global.it = originalIt;
-  if (originalBeforeEach) global.beforeEach = originalBeforeEach;
-  if (originalAfterEach) global.afterEach = originalAfterEach;
-
-  if (testsFailed > 0) {
-    //throw new Error(`${testsFailed} test(s) failed.`);
-    // For the agent, we might not want to throw an error that stops execution,
-    // but rather report it. The console logs should be sufficient.
-    console.error(`${testsFailed} test(s) failed. Check logs above.`);
-  } else {
-    console.log("All SymbolLibrary tests passed!");
-  }
-})().catch(e => {
-  console.error("Error running basic test runner:", e);
+    // Or check via customElements.get
+    const Ctor = customElements.get('symbol-library');
+    expect(Ctor).toBeDefined();
+    expect(Ctor).toBe(SymbolLibrary);
+    expect(el).toBeInstanceOf(Ctor);
+  });
 });


### PR DESCRIPTION
…DME.

Specifically, I:
- Refactored `symbol-library.test.js` to use Vitest syntax.
- Refactored `canvas-workspace.test.js` to use Vitest syntax.
- These changes align the component tests with your project's established Vitest testing framework.

Additionally, I updated the README task list by:
- Marking Task 1.4 (canvas-workspace) and Task 2.1 (symbol-library) as having their initial placeholder versions implemented.
- Confirming that the existing `npm test` instruction in the README is appropriate for running all tests.