### PR TITLE
I've implemented pan and zoom functionality in the `canvas-workspace`.

### DIFF
--- a/src/canvas-workspace/canvas-workspace.js
+++ b/src/canvas-workspace/canvas-workspace.js
@@ -3,15 +3,92 @@ import BaseComponent from '../BaseComponent.js';
 class CanvasWorkspace extends BaseComponent {
   constructor() {
     super();
+    this.isPanning = false;
+    this.startX = 0;
+    this.startY = 0;
+    this.currentX = 0;
+    this.currentY = 0;
+    this.currentScale = 1;
   }
 
   connectedCallback() {
-    this.innerHTML = `
-      <div style="width:100%; height:100%; background-color: #f0f0f0; display:flex; align-items:center; justify-content:center;">
-        Canvas Workspace Placeholder
-      </div>
-    `;
+    this.svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    this.svg.setAttribute('width', '100%');
+    this.svg.setAttribute('height', '100%');
+    this.svg.style.backgroundColor = '#f0f0f0';
+
+    this.g = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+    this.g.setAttribute('transform', `translate(${this.currentX}, ${this.currentY})`);
+    this.svg.appendChild(this.g);
+
+    // Add some sample content to the group
+    const rect = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+    rect.setAttribute('x', '50');
+    rect.setAttribute('y', '50');
+    rect.setAttribute('width', '100');
+    rect.setAttribute('height', '100');
+    rect.setAttribute('fill', 'blue');
+    this.g.appendChild(rect);
+
+    const text = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+    text.setAttribute('x', '60');
+    text.setAttribute('y', '100');
+    text.textContent = 'Pan me!';
+    this.g.appendChild(text);
+
+
+    this.appendChild(this.svg);
+
+    this.svg.addEventListener('mousedown', this.handleMouseDown.bind(this));
+    this.svg.addEventListener('mousemove', this.handleMouseMove.bind(this));
+    this.svg.addEventListener('mouseup', this.handleMouseUp.bind(this));
+    this.svg.addEventListener('mouseleave', this.handleMouseUp.bind(this)); // Reset panning if mouse leaves canvas
+    this.svg.addEventListener('wheel', this.handleWheel.bind(this));
+
     console.log('canvas-workspace connected');
+  }
+
+  handleMouseDown(event) {
+    this.isPanning = true;
+    this.startX = event.clientX - this.currentX;
+    this.startY = event.clientY - this.currentY;
+    this.svg.style.cursor = 'grabbing';
+  }
+
+  handleMouseMove(event) {
+    if (!this.isPanning) {
+      return;
+    }
+    this.currentX = event.clientX - this.startX;
+    this.currentY = event.clientY - this.startY;
+    this.updateTransform();
+  }
+
+  handleMouseUp() {
+    this.isPanning = false;
+    this.svg.style.cursor = 'grab';
+  }
+
+  handleWheel(event) {
+    event.preventDefault();
+    const zoomFactor = event.deltaY < 0 ? 1.1 : 0.9;
+    const rect = this.svg.getBoundingClientRect();
+    const mouseX = event.clientX - rect.left;
+    const mouseY = event.clientY - rect.top;
+
+    // Calculate the new scale
+    const newScale = this.currentScale * zoomFactor;
+
+    // Adjust translation to keep zoom centered on mouse pointer
+    this.currentX = mouseX - (mouseX - this.currentX) * zoomFactor;
+    this.currentY = mouseY - (mouseY - this.currentY) * zoomFactor;
+    this.currentScale = newScale;
+
+    this.updateTransform();
+  }
+
+  updateTransform() {
+    this.g.setAttribute('transform', `translate(${this.currentX}, ${this.currentY}) scale(${this.currentScale})`);
   }
 }
 

--- a/src/canvas-workspace/canvas-workspace.test.js
+++ b/src/canvas-workspace/canvas-workspace.test.js
@@ -13,59 +13,207 @@ describe('CanvasWorkspace Component', () => {
     // Create the element and append it to the container
     element = new CanvasWorkspace();
     container.appendChild(element);
+    // Ensure SVG and g elements are present after connectedCallback
+    element.connectedCallback();
   });
 
   afterEach(() => {
-    // Remove the element from its container
     if (element && element.parentNode) {
       element.parentNode.removeChild(element);
     }
-    // Remove the container from the body
     if (container && container.parentNode) {
       container.parentNode.removeChild(container);
     }
     element = null;
     container = null;
+    // Vitest specific: clear any mocks or spies if used
+    // vi.clearAllMocks();
   });
 
-  it('should render a placeholder for the canvas', () => {
-    expect(element).not.toBeNull();
+  // Helper function to dispatch mouse events
+  const dispatchMouseEvent = (target, type, clientX, clientY) => {
+    const event = new MouseEvent(type, {
+      bubbles: true,
+      cancelable: true,
+      clientX: clientX,
+      clientY: clientY,
+    });
+    target.dispatchEvent(event);
+  };
 
-    const placeholderDiv = element.querySelector('div');
-    expect(placeholderDiv).not.toBeNull();
-
-    if (placeholderDiv) {
-      // Assert content
-      expect(placeholderDiv.textContent).toContain('Canvas Workspace Placeholder');
-
-      // Assert styles more directly using Vitest's toHaveStyle or by checking style properties
-      // For inline styles, direct property access is fine.
-      // getComputedStyle is more robust for styles from stylesheets.
-      expect(placeholderDiv.style.width).toBe('100%');
-      expect(placeholderDiv.style.height).toBe('100%');
-      expect(placeholderDiv.style.backgroundColor).toBe('rgb(240, 240, 240)'); // #f0f0f0
-      expect(placeholderDiv.style.display).toBe('flex');
-      expect(placeholderDiv.style.alignItems).toBe('center');
-      expect(placeholderDiv.style.justifyContent).toBe('center');
-
-      // Alternative: Check the style attribute string for multiple properties at once
-      const styleAttribute = placeholderDiv.getAttribute('style');
-      expect(styleAttribute).toContain('width:100%');
-      expect(styleAttribute).toContain('height:100%');
-      expect(styleAttribute).toContain('background-color: #f0f0f0');
-      expect(styleAttribute).toContain('display:flex');
-      expect(styleAttribute).toContain('align-items:center');
-      expect(styleAttribute).toContain('justify-content:center');
-    }
-  });
+  // Helper function to dispatch wheel events
+  const dispatchWheelEvent = (target, deltaY, clientX, clientY) => {
+    const event = new WheelEvent('wheel', {
+      bubbles: true,
+      cancelable: true,
+      deltaY: deltaY,
+      clientX: clientX,
+      clientY: clientY,
+    });
+    target.dispatchEvent(event);
+  };
 
   it('should be registered as a custom element canvas-workspace', () => {
     const el = document.createElement('canvas-workspace');
-    expect(el).toBeInstanceOf(CanvasWorkspace); // Check instance type
-
+    expect(el).toBeInstanceOf(CanvasWorkspace);
     const Ctor = customElements.get('canvas-workspace');
     expect(Ctor).toBeDefined();
-    expect(Ctor).toBe(CanvasWorkspace); // Check if the registered constructor is the imported class
-    expect(el).toBeInstanceOf(Ctor); // Check if the created element is an instance of the registered constructor
+    expect(Ctor).toBe(CanvasWorkspace);
+    expect(el).toBeInstanceOf(Ctor);
+  });
+
+  it('should have an SVG element with a group (g) child', () => {
+    expect(element.svg).toBeInstanceOf(SVGElement);
+    expect(element.g).toBeInstanceOf(SVGElement);
+    expect(element.g.parentElement).toBe(element.svg);
+  });
+
+  it('should initialize with default transform values', () => {
+    expect(element.g.getAttribute('transform')).toBe('translate(0, 0) scale(1)');
+  });
+
+  describe('Pan Functionality', () => {
+    it('should update transform on pan', () => {
+      const svg = element.svg;
+      // Mock getBoundingClientRect for SVG if necessary, though not strictly needed for transform logic
+      // For this test, clientX/Y are sufficient as we are testing the delta.
+
+      // Start panning
+      dispatchMouseEvent(svg, 'mousedown', 100, 100);
+      expect(element.isPanning).toBe(true);
+      // Initial transform based on currentX/Y (0,0) and mouse (100,100)
+      // startX = 100 - 0 = 100; startY = 100 - 0 = 100;
+
+      // Move mouse
+      dispatchMouseEvent(svg, 'mousemove', 150, 120);
+      // currentX = 150 - 100 = 50; currentY = 120 - 100 = 20;
+      expect(element.g.getAttribute('transform')).toBe('translate(50, 20) scale(1)');
+
+      // Move mouse again
+      dispatchMouseEvent(svg, 'mousemove', 50, 80);
+      // currentX = 50 - 100 = -50; currentY = 80 - 100 = -20;
+      expect(element.g.getAttribute('transform')).toBe('translate(-50, -20) scale(1)');
+
+      // Stop panning
+      dispatchMouseEvent(svg, 'mouseup', 50, 80);
+      expect(element.isPanning).toBe(false);
+    });
+  });
+
+  describe('Zoom Functionality', () => {
+    beforeEach(() => {
+      // Mock getBoundingClientRect for the SVG element for accurate zoom centering
+      // Vitest's happy-dom doesn't fully implement getBoundingClientRect for SVG elements in all contexts.
+      // We need to provide a mock implementation.
+      element.svg.getBoundingClientRect = () => ({
+        left: 0,
+        top: 0,
+        width: 800, // Example width
+        height: 600, // Example height
+        right: 800,
+        bottom: 600,
+        x: 0,
+        y: 0,
+      });
+    });
+
+    it('should zoom in correctly, centered on mouse pointer', () => {
+      const svg = element.svg;
+      // Initial state: translate(0,0) scale(1)
+
+      // Zoom in at (100,100)
+      // mouseX = 100, mouseY = 100
+      // currentX = 0, currentY = 0, currentScale = 1
+      // zoomFactor = 1.1
+      // newScale = 1 * 1.1 = 1.1
+      // currentX = 100 - (100 - 0) * 1.1 = 100 - 110 = -10
+      // currentY = 100 - (100 - 0) * 1.1 = 100 - 110 = -10
+      dispatchWheelEvent(svg, -100, 100, 100); // deltaY < 0 for zoom in
+      expect(element.currentScale).toBeCloseTo(1.1);
+      expect(element.currentX).toBeCloseTo(-10);
+      expect(element.currentY).toBeCloseTo(-10);
+      expect(element.g.getAttribute('transform')).toBe(`translate(-10, -10) scale(1.1)`);
+
+      // Zoom in again at a different point (200,200)
+      // mouseX = 200, mouseY = 200
+      // currentX = -10, currentY = -10, currentScale = 1.1
+      // zoomFactor = 1.1
+      // newScale = 1.1 * 1.1 = 1.21
+      // currentX = 200 - (200 - (-10)) * 1.1 = 200 - (210) * 1.1 = 200 - 231 = -31
+      // currentY = 200 - (200 - (-10)) * 1.1 = 200 - (210) * 1.1 = 200 - 231 = -31
+      dispatchWheelEvent(svg, -100, 200, 200);
+      expect(element.currentScale).toBeCloseTo(1.21);
+      expect(element.currentX).toBeCloseTo(-31);
+      expect(element.currentY).toBeCloseTo(-31);
+      expect(element.g.getAttribute('transform')).toBe(`translate(-31, -31) scale(1.21)`);
+    });
+
+    it('should zoom out correctly, centered on mouse pointer', () => {
+      const svg = element.svg;
+      // Initial state: translate(0,0) scale(1)
+
+      // Zoom out at (100,100)
+      // mouseX = 100, mouseY = 100
+      // currentX = 0, currentY = 0, currentScale = 1
+      // zoomFactor = 0.9
+      // newScale = 1 * 0.9 = 0.9
+      // currentX = 100 - (100 - 0) * 0.9 = 100 - 90 = 10
+      // currentY = 100 - (100 - 0) * 0.9 = 100 - 90 = 10
+      dispatchWheelEvent(svg, 100, 100, 100); // deltaY > 0 for zoom out
+      expect(element.currentScale).toBeCloseTo(0.9);
+      expect(element.currentX).toBeCloseTo(10);
+      expect(element.currentY).toBeCloseTo(10);
+      expect(element.g.getAttribute('transform')).toBe(`translate(10, 10) scale(0.9)`);
+
+      // Zoom out again at a different point (50,50)
+      // mouseX = 50, mouseY = 50
+      // currentX = 10, currentY = 10, currentScale = 0.9
+      // zoomFactor = 0.9
+      // newScale = 0.9 * 0.9 = 0.81
+      // currentX = 50 - (50 - 10) * 0.9 = 50 - (40) * 0.9 = 50 - 36 = 14
+      // currentY = 50 - (50 - 10) * 0.9 = 50 - (40) * 0.9 = 50 - 36 = 14
+      dispatchWheelEvent(svg, 100, 50, 50);
+      expect(element.currentScale).toBeCloseTo(0.81);
+      expect(element.currentX).toBeCloseTo(14);
+      expect(element.currentY).toBeCloseTo(14);
+      // Due to potential floating point inaccuracies, it's better to check parts of the string or use toBeCloseTo for numerical values
+      const transform = element.g.getAttribute('transform');
+      expect(transform).toContain(`scale(0.81)`);
+      // For translate, parse the values if precision is an issue.
+      // Or ensure the component rounds or formats the output consistently.
+      // For now, direct string comparison with calculated values.
+      expect(transform).toBe(`translate(14, 14) scale(0.81)`);
+    });
+
+    it('should handle mixed pan and zoom operations', () => {
+      const svg = element.svg;
+      // 1. Pan
+      dispatchMouseEvent(svg, 'mousedown', 100, 100);
+      dispatchMouseEvent(svg, 'mousemove', 150, 130); // dx=50, dy=30. translate(50,30) scale(1)
+      dispatchMouseEvent(svg, 'mouseup', 150, 130);
+      expect(element.g.getAttribute('transform')).toBe('translate(50, 30) scale(1)');
+
+      // 2. Zoom In at (150, 130) - this is relative to SVG, current element.currentX = 50, element.currentY = 30
+      // mouseX = 150, mouseY = 130
+      // currentX = 50, currentY = 30, currentScale = 1
+      // zoomFactor = 1.1
+      // newScale = 1.1
+      // nextX = 150 - (150 - 50) * 1.1 = 150 - 100 * 1.1 = 150 - 110 = 40
+      // nextY = 130 - (130 - 30) * 1.1 = 130 - 100 * 1.1 = 130 - 110 = 20
+      dispatchWheelEvent(svg, -100, 150, 130);
+      expect(element.currentScale).toBeCloseTo(1.1);
+      expect(element.currentX).toBeCloseTo(40);
+      expect(element.currentY).toBeCloseTo(20);
+      expect(element.g.getAttribute('transform')).toBe(`translate(40, 20) scale(1.1)`);
+
+      // 3. Pan again
+      // currentX = 40, currentY = 20, currentScale = 1.1
+      dispatchMouseEvent(svg, 'mousedown', 100, 100); // startX = 100 - 40 = 60, startY = 100 - 20 = 80
+      dispatchMouseEvent(svg, 'mousemove', 120, 110); // nextX = 120 - 60 = 60, nextY = 110 - 80 = 30
+      dispatchMouseEvent(svg, 'mouseup', 120, 110);
+      expect(element.currentX).toBeCloseTo(60);
+      expect(element.currentY).toBeCloseTo(30);
+      expect(element.g.getAttribute('transform')).toBe(`translate(60, 30) scale(1.1)`);
+    });
   });
 });


### PR DESCRIPTION
This commit introduces basic pan and zoom capabilities to the `canvas-workspace` component.

Pan functionality:
- You can pan the canvas by clicking and dragging.
- I implemented this using `mousedown`, `mousemove`, and `mouseup` event listeners.
- The `transform` attribute of the main SVG group is updated to reflect panning.

Zoom functionality:
- You can zoom in and out using the mouse wheel.
- I implemented this using the `wheel` event listener.
- Zooming is centered around the mouse pointer position.
- The `transform` attribute of the main SVG group is updated to reflect scaling and translation adjustments for centered zooming.

I also added unit tests for both pan and zoom functionalities in `canvas-workspace.test.js`. These tests cover:
- Correct transform updates during panning.
- Correct transform updates during zooming (both in and out).
- Accurate centering of zoom around the mouse pointer.
- Combined pan and zoom operations. Helper functions were added to simulate mouse and wheel events, and `getBoundingClientRect` is mocked for zoom tests to ensure accurate calculations in the JSDOM environment.